### PR TITLE
Fixes bug with str not having attribute close() in simulator modules

### DIFF
--- a/BSP/Simulator/Hardware/CAN.py
+++ b/BSP/Simulator/Hardware/CAN.py
@@ -14,8 +14,8 @@ def read():
     # Creates file if it doesn't exist
     os.makedirs(os.path.dirname(file), exist_ok=True)
     if not os.path.exists(file):
-        open(file, 'w')
-        file.close()
+        with open(file, 'w'):
+            pass
     message = []
     with open(file, 'r') as csvfile:
         fcntl.flock(csvfile.fileno(), fcntl.LOCK_EX)

--- a/BSP/Simulator/Hardware/Contactor.py
+++ b/BSP/Simulator/Hardware/Contactor.py
@@ -11,8 +11,8 @@ def read():
     """
     os.makedirs(os.path.dirname(file), exist_ok=True)
     if not os.path.exists(file):
-        open(file, 'w')
-        file.close()
+        with open(file, 'w'):
+            pass
 
     with open(file, 'r') as csvfile:
         fcntl.flock(csvfile.fileno(), fcntl.LOCK_EX)    # Lock file before reading

--- a/BSP/Simulator/Hardware/Display.py
+++ b/BSP/Simulator/Hardware/Display.py
@@ -34,8 +34,8 @@ def read():
     # Creates file if it doesn't exist
     os.makedirs(os.path.dirname(file), exist_ok=True)
     if not os.path.exists(file):
-        open(file, 'w')
-        file.close()
+        with open(file, 'w'):
+            pass
     uart = list()
     with open(file, 'r') as csvfile:
         fcntl.flock(csvfile.fileno(), fcntl.LOCK_EX)
@@ -46,5 +46,8 @@ def read():
     if len(uart):
         uart = uart[0]
         for i, d in enumerate(data.keys()):
-            data[d] = uart[i]
+            try:
+                data[d] = uart[i]
+            except:
+                pass
     return data

--- a/BSP/Simulator/Hardware/MotorController.py
+++ b/BSP/Simulator/Hardware/MotorController.py
@@ -24,8 +24,8 @@ def read():
     # Creates file if it doesn't exist
     os.makedirs(os.path.dirname(file), exist_ok=True)
     if not os.path.exists(file):
-        open(file, 'w')
-        file.close()
+        with open(file, 'w'):
+            pass
     message = []
     with open(file, 'r') as csvfile:
         fcntl.flock(csvfile.fileno(), fcntl.LOCK_EX)

--- a/BSP/Simulator/Hardware/Pedals.py
+++ b/BSP/Simulator/Hardware/Pedals.py
@@ -16,8 +16,8 @@ def set_pedals(accel_pos, brake_pos):
     # Create the file if it doesn't exist yet
     os.makedirs(os.path.dirname(file), exist_ok=True)
     if not os.path.exists(file):
-        open(file, 'w')
-        file.close()
+        with open(file, 'w'):
+            pass
     accel_value = int(float(accel_pos) * 4096) # ADC conversion
     brake_value = int(float(brake_pos) * 4096) # ADC conversion
     # The slider goes from 0.0 to 1.0, but we want to cap the ADC value at 4095

--- a/BSP/Simulator/Hardware/Switches.py
+++ b/BSP/Simulator/Hardware/Switches.py
@@ -49,8 +49,8 @@ def read():
     # Creates file if it doesn't exist
     os.makedirs(os.path.dirname(file), exist_ok=True)
     if not os.path.exists(file):
-        open(file, 'w')
-        file.close()
+        with open(file, 'w'):
+            pass
     states = []
     with open(file, 'r') as csvfile:
         fcntl.flock(csvfile.fileno(), fcntl.LOCK_EX)

--- a/BSP/Simulator/Hardware/Timer.py
+++ b/BSP/Simulator/Hardware/Timer.py
@@ -11,8 +11,8 @@ def update():
 	# Create the file if it doesn't exist yet
 	os.makedirs(os.path.dirname(file), exist_ok=True)
 	if not os.path.exists(file):
-		open(file, 'w')
-		file.close()
+		with open(file, 'w'):
+			pass
 
 	current_values = []
 	reload_values = []

--- a/BSP/Simulator/Hardware/UART.py
+++ b/BSP/Simulator/Hardware/UART.py
@@ -14,8 +14,8 @@ def write(msg):
     # Creates file if it doesn't exist
     os.makedirs(os.path.dirname(file), exist_ok=True)
     if not os.path.exists(file):
-        open(file, 'w')
-        file.close()
+        with open(file, 'w'):
+            pass
     
     lines = []
     # Grab the current UART data


### PR DESCRIPTION
Problem
======
When a file in the Data folder had not yet been created, each Python simulation module would create that file and then try to close it. The variable that `close()` was being called on was a `str`, so there were type mismatch errors. 

Solution
======
Use a `with` block to automatically close the file and remove all incorrect closes of the `str` that contained the name and path of the CSV file.

Closes #44 