### PR TITLE
MotorController_Drive Parameter types changed

### DIFF
--- a/Drivers/Inc/MotorController.h
+++ b/Drivers/Inc/MotorController.h
@@ -21,11 +21,11 @@ void MotorController_Init(void);
 
 /**
  * @brief   Sends MOTOR DRIVE command on CAN2
- * @param   newVelocity desired motor velocity setpoint in m/s
- * @param   motorCurrent desired motor current setpoint as a percentage of max current setting
+ * @param   newVelocity desired motor velocity setpoint in rpm
+ * @param   motorCurrent desired motor current setpoint as a fraction of max current setting
  * @return  None
  */ 
-void MotorController_Drive(uint32_t newVelocity, uint32_t motorCurrent);
+void MotorController_Drive(float newVelocity, float motorCurrent);
 
 /**
  * @brief   Reads most recent command from CAN2 bus

--- a/Drivers/Src/MotorController.c
+++ b/Drivers/Src/MotorController.c
@@ -19,17 +19,21 @@ void MotorController_Init(){
  * @param   motorCurrent desired motor current setpoint as a percentage of max current setting
  * @return  None
  */ 
-void MotorController_Drive(uint32_t newVelocity, uint32_t motorCurrent){
+void MotorController_Drive(float newVelocity, float motorCurrent){
+
+    uint32_t nv = *((uint32_t *)((void *) &newVelocity));
+    uint32_t mc = *((uint32_t *)((void *) &motorCurrent));
+
     uint8_t data[8] = {0};
     int index = 0;
     while(index < MAX_CAN_LEN/2){
-        data[index] = (motorCurrent >> (8 * (MAX_CAN_LEN/2-index-1))) & 0xFF; //split inputs into bytes
+        data[index] = (mc >> (8 * (MAX_CAN_LEN/2-index-1))) & 0xFF; //split inputs into bytes
         index++;
         
     }
     int i = 0;
     while(index < MAX_CAN_LEN){
-        data[index] = (newVelocity >> (8 * (MAX_CAN_LEN/2-i-1))) & 0xFF;
+        data[index] = (nv >> (8 * (MAX_CAN_LEN/2-i-1))) & 0xFF;
         index++;
         i++;
     }

--- a/Tests/Test_MotorController.c
+++ b/Tests/Test_MotorController.c
@@ -13,14 +13,14 @@
 int main(){
     
     MotorController_Init();
-    uint32_t input1 = 0x5053;
-    uint32_t input2 = 0x4056;
+    float input1 = 2500.0f;
+    float input2 = 1.0f;
     MotorController_Drive(input1,input2);
-    
+    usleep(1000000);
     CANbuff tester = {0, 0, 0};
     uint32_t id = 0x243;
     uint8_t data[8] = {0x00, 0x55, 0x55, 0x22,     0x11, 0x11, 0x11, 0x11};
-    BSP_CAN_Write(CAN_2, id, data, 8);
+    //BSP_CAN_Write(CAN_2, id, data, 8);
     bool check = MotorController_Read(&tester);
     printf("The ID on the bus was: %x\n\rMessage: %x, %x\n\rSuccess: %d",tester.id, tester.firstNum, tester.secondNum, check); 
     exit(0);


### PR DESCRIPTION
MotorController_Drive now takes in two floats instead of uin32_t.
Instead of accepting velocity in m/s, it is now accepted in rpm.