### PR TITLE
Removed broken task macro

### DIFF
--- a/Apps/Inc/Tasks.h
+++ b/Apps/Inc/Tasks.h
@@ -16,23 +16,6 @@
  * @param err the local OS_ERR variable
  */
 
-#define _CONCAT(A, B) A ## B
-#define CONCAT(A, B) _CONCAT(A, B)
-#define INIT_TASK(task, prio, arg, err) \
-        OSTaskCreate(&CONCAT(task, _TCB),\
-                     #task,\
-                     task,\
-                     (void*) arg,\
-                     prio,\
-                     CONCAT(task, _Stk),\
-                     WATERMARK_STACK_LIMIT,\
-                     DEFAULT_STACK_SIZE,\
-                     0,\
-                     0,\
-                     (void *)0,\
-                     OS_OPT_TASK_STK_CLR,\
-                     &err);
-
 /**
  * Priority Definitions
  */


### PR DESCRIPTION
The INIT_TASK macro is broken and should no longer used. Any test file that uses it should be rewritten to call the TaskCreate function manually.