### PR TITLE
UpdateLights Task

### DIFF
--- a/Apps/Inc/CarState.h
+++ b/Apps/Inc/CarState.h
@@ -5,6 +5,7 @@
 
 #include "common.h"
 #include "config.h"
+#include "Switches.h"
 
 
 /**
@@ -20,37 +21,6 @@ typedef struct{
     State overSpeedErr;
 } motor_error_code_t;
 
-/**
- * Switch States
- * 
- * Stores the current state of each of
- * the switches that control this system
- */
-typedef struct {
-    State LT;
-    State RT;
-    State FWD;
-    State REV;
-    State CRS_EN;
-    State CRS_SET;
-    State REGEN;
-    State HZD;
-    State HDLT;
-    State IGN_1;
-    State IGN_2;
-} switch_states_t;
-
-/**
- * Blinker States
- * 
- * Stores the desired blinker state
- * to indicate which lights to toggle
- */
-typedef struct {
-    State HZD;
-    State LT;
-    State RT;
-} blinker_states_t;
 
 /**
  * Error States
@@ -103,10 +73,8 @@ typedef struct {
     uint8_t AccelPedalPercent;
     uint8_t BrakePedalPercent;
     uint8_t MotorCurrentSetpoint;
-
+    
     switch_states_t SwitchStates;
-    blinker_states_t BlinkerStates;
-
     CruiseRegenSet CRSet;
     State CruiseControlEnable;
     

--- a/Apps/Src/UpdateLights.c
+++ b/Apps/Src/UpdateLights.c
@@ -1,6 +1,6 @@
 #include "Lights.h"
 #include "Tasks.h"
-#define BRAKETHRESHOLD 2
+#define BRAKETHRESHOLD 3
 
 /**
  * @brief This task waits on the Update Lights Semaphore, then reads the switches that pertain to the lights from the global carstate
@@ -11,7 +11,7 @@
 void Task_UpdateLights(void* p_arg){
     car_state_t* GlobalCarState = (car_state_t*) p_arg;
     switch_states_t* GlobalSwitchStates = &(GlobalCarState->SwitchStates);
-    //Note: the below code is based off the switch_states_t struct defined in the RTOS_ReadSwitches branch rather than the current one
+    //Note: the below code is based off the switch_states_t struct defined in the RTOS_ReadSwitches branch rather than main
     light_switches_t* GlobalLightSwitches = &(GlobalSwitchStates->lightSwitches);
     OS_ERR err;
     CPU_TS ts;

--- a/Apps/Src/UpdateLights.c
+++ b/Apps/Src/UpdateLights.c
@@ -1,0 +1,62 @@
+#include "Lights.h"
+#include "Tasks.h"
+#define BRAKETHRESHOLD 2
+
+/**
+ * @brief This task waits on the Update Lights Semaphore, then reads the switches that pertain to the lights from the global carstate
+ * (UpdateSwitches will have already updated this). Using those values it uses the lights driver to set the lights to the pertinent values.
+ * 
+ * @param p_arg 
+ */
+void Task_UpdateLights(void* p_arg){
+    car_state_t* GlobalCarState = (car_state_t*) p_arg;
+    switch_states_t* GlobalSwitchStates = &(GlobalCarState->SwitchStates);
+    //Note: the below code is based off the switch_states_t struct defined in the RTOS_ReadSwitches branch rather than the current one
+    light_switches_t* GlobalLightSwitches = &(GlobalSwitchStates->lightSwitches);
+    OS_ERR err;
+    CPU_TS ts;
+    while(1){
+        OSSemPend(
+            &LightsChange_Sem4,
+            0,
+            OS_OPT_PEND_BLOCKING,
+            &ts,
+            &err
+        );
+        if(GlobalLightSwitches->HEADLIGHT_SW == ON){
+            Lights_Set(Headlight_ON,ON);
+        } else {
+            Lights_Set(Headlight_ON,OFF);
+        }
+
+        if(GlobalLightSwitches->HZD_SW == ON){
+            //TODO: Signal BlinkLights Sem4
+        } else if (GlobalLightSwitches->LEFT_SW==ON){
+            //TODO: Signal BlinkLights Sem4
+        } else if (GlobalLightSwitches->RIGHT_SW==ON){
+            //TODO: Signal BlinkLights Sem4
+        } else {
+            Lights_Set(LEFT_BLINK,OFF);
+            Lights_Set(RIGHT_BLINK,OFF);
+        }
+
+        if(GlobalCarState->BrakePedalPercent>=BRAKETHRESHOLD){
+            Lights_Set(BrakeLight,ON);
+        } else {
+            Lights_Set(BrakeLight,OFF);
+        }
+
+        if(GlobalCarState->ShouldArrayBeActivated==ON){
+            Lights_Set(A_CNCTR,ON);
+        } else {
+            Lights_Set(A_CNCTR,OFF);
+        }
+
+        if(GlobalCarState->ShouldMotorBeActivated==ON){
+            Lights_Set(M_CNCTR,ON);
+        } else {
+            Lights_Set(M_CNCTR,OFF);
+        }
+
+    }
+}

--- a/Apps/Src/UpdateLights.c
+++ b/Apps/Src/UpdateLights.c
@@ -29,12 +29,12 @@ void Task_UpdateLights(void* p_arg){
             Lights_Set(Headlight_ON,OFF);
         }
 
-        if(GlobalLightSwitches->HZD_SW == ON){
-            //TODO: Signal BlinkLights Sem4
-        } else if (GlobalLightSwitches->LEFT_SW==ON){
-            //TODO: Signal BlinkLights Sem4
-        } else if (GlobalLightSwitches->RIGHT_SW==ON){
-            //TODO: Signal BlinkLights Sem4
+        if(GlobalLightSwitches->HZD_SW == ON || GlobalLightSwitches->LEFT_SW == ON || GlobalLightSwitches->RIGHT_SW ==ON){
+            OSSemPost(
+                &BlinkLight_Sem4,
+                OS_OPT_POST_ALL,
+                &err
+            );
         } else {
             Lights_Set(LEFT_BLINK,OFF);
             Lights_Set(RIGHT_BLINK,OFF);

--- a/Drivers/Inc/Switches.h
+++ b/Drivers/Inc/Switches.h
@@ -6,8 +6,65 @@
 #include "config.h"
 #include "GPIOExpander.h"
 
+/**
+ * Switches enum
+ * 
+ * All of our switches names
+*/
+typedef enum {
+    CRUZ_SW=0,
+    CRUZ_EN,
+    HZD_SW, 
+    FWD_SW, 
+    HEADLIGHT_SW, 
+    LEFT_SW, 
+    RIGHT_SW, 
+    REGEN_SW, 
+    IGN_1, 
+    IGN_2, 
+    REV_SW
+} switches_t;
 
-typedef enum {CRUZ_SW=0, CRUZ_EN, HZD_SQ, FR_SW, HEADLIGHT_SW, LEFT_SW, RIGHT_SW, REGEN_SW, IGN_1, IGN_2, REV_SW} switches_t;
+
+/**
+ * Switches that pertain to lights
+*/
+typedef struct {
+    State LEFT_SW;
+    State RIGHT_SW;
+    State HEADLIGHT_SW;
+    State HZD_SW;
+}light_switches_t;
+
+/**
+ * Switches that pertain to velocity
+*/
+typedef struct {
+    State CRUZ_SW;
+    State CRUZ_EN;
+    State FWD_SW;
+    State REV_SW;
+    State REGEN_SW;
+}velocity_switches_t;
+
+
+
+/**
+ * Switch States
+ * 
+ * Stores the current state all of
+ * the switches that control this system
+ */
+
+typedef struct {
+    State IGN_1;
+    State IGN_2;
+    velocity_switches_t velDispSwitches;
+    light_switches_t lightSwitches;
+}switch_states_t;
+
+
+
 
 /**
  * @brief   Initializes all switches

--- a/Drivers/Src/Switches.c
+++ b/Drivers/Src/Switches.c
@@ -54,8 +54,8 @@ State Switches_Read(switches_t sw){
     switch(sw) {
     case CRUZ_SW:
     case CRUZ_EN:
-    case HZD_SQ: 
-    case FR_SW: 
+    case HZD_SW: 
+    case FWD_SW: 
     case HEADLIGHT_SW: 
     case LEFT_SW: 
     case RIGHT_SW: 


### PR DESCRIPTION
Addresses Issue #109.  Implements the Update lights thread with the semaphore signaling the BlinkLights thread architecture. This may have to be revisited if we decide to remove the signaling semaphore for BlinkLights as discussed [here][https://github.com/lhr-solar/Controls/pull/168#discussion_r776517042](https://github.com/lhr-solar/Controls/pull/168/files#r762465782)