### PR TITLE
Suggestion: treat compiler warnings as errors

### DIFF
--- a/BSP/STM32F413/Makefile
+++ b/BSP/STM32F413/Makefile
@@ -116,7 +116,7 @@ C_INCLUDES =  \
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
-CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
+CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Werror -fdata-sections -ffunction-sections
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g3 -gdwarf-2


### PR DESCRIPTION
I added -Werror to the stm32f413 Makefile, so the code will not compile if there are any warnings. I like this because it stops people from adding warnings to mainline, but it's up to you if you want to merge this @babusid 