### PR TITLE
Adc overhaul

### DIFF
--- a/BSP/STM32F413/Src/BSP_ADC.c
+++ b/BSP/STM32F413/Src/BSP_ADC.c
@@ -92,7 +92,7 @@ void BSP_ADC_Init(void) {
  * @param   None
  * @return  millivoltage value ADC measurement
  */
-int16_t BSP_ADC_High_GBSP_ADC_Get_Value(ADC_t hardwareDevice) {
+int16_t BSP_ADC_Get_Value(ADC_t hardwareDevice) {
 
     // Get ADC raw data
     uint16_t data = ADCresults[hardwareDevice];

--- a/Drivers/Src/Pedals.c
+++ b/Drivers/Src/Pedals.c
@@ -6,6 +6,19 @@
 
 #include "Pedals.h"
 
+// Constants used to tune the pedals
+// Indexed using pedal_t
+// Refine in testing
+static const int16_t LowerBound[NUMBER_OF_PEDALS] = {
+    1000, // Accelerator lower bound
+    2000, // Brake lower bound
+};
+
+static const int16_t UpperBound[NUMBER_OF_PEDALS] = {
+    ADC_RANGE_MILLIVOLTS, // Accelerator upper bound
+    ADC_RANGE_MILLIVOLTS, // Brake upper bound
+};
+
 /**
  * @brief   Initializes the brake and accelerator by using the 
  *          BSP_ADC_Init function with parameters ACCELERATOR
@@ -20,14 +33,22 @@ void Pedals_Init(){
 /**
  * @brief   Fetches the millivoltage value of the potentiomenter as provided 
  *          by the ADC channel of the requested pedal (Accelerator or Brake),
- *          converts it to a percentage of the total distance pressed and 
- *          returns it
+ *          converts it to a percentage of the total distance pressed using 
+ *          data from calibration testing, and returns it
  * @param   pedal_t, ACCELERATOR or BRAKE as defined in enum
  * @return  distance the pedal has been pressed in percentage
  */
 int8_t Pedals_Read(pedal_t pedal){
+    if (pedal >= NUMBER_OF_PEDALS) return 0;
     int16_t millivoltsPedal = BSP_ADC_Get_Millivoltage(pedal);
-    int8_t percentage = millivoltsPedal * 100 / ADC_RANGE_MILLIVOLTS;
+
+    int8_t percentage = 0;
+    
+    if (millivoltsPedal >= LowerBound[pedal]) {
+        percentage = (millivoltsPedal - LowerBound[pedal]) * 100 /
+            (UpperBound[pedal] - 1000);
+    }
+
     return percentage;
 }
 

--- a/Drivers/Src/Pedals.c
+++ b/Drivers/Src/Pedals.c
@@ -45,8 +45,8 @@ int8_t Pedals_Read(pedal_t pedal){
     int8_t percentage = 0;
     
     if (millivoltsPedal >= LowerBound[pedal]) {
-        percentage = (int8_t) (millivoltsPedal - LowerBound[pedal]) * 100 /
-         (UpperBound[pedal] - LowerBound[pedal]);
+        percentage = (int8_t) ( (int32_t) (millivoltsPedal - LowerBound[pedal]) * 100 /
+         (UpperBound[pedal] - LowerBound[pedal]));
     }
 
     return percentage;

--- a/Drivers/Src/Pedals.c
+++ b/Drivers/Src/Pedals.c
@@ -46,7 +46,7 @@ int8_t Pedals_Read(pedal_t pedal){
     
     if (millivoltsPedal >= LowerBound[pedal]) {
         percentage = (millivoltsPedal - LowerBound[pedal]) * 100 /
-            (UpperBound[pedal] - 1000);
+            (UpperBound[pedal] - LowerBound[pedal]);
     }
 
     return percentage;

--- a/Drivers/Src/Pedals.c
+++ b/Drivers/Src/Pedals.c
@@ -40,13 +40,13 @@ void Pedals_Init(){
  */
 int8_t Pedals_Read(pedal_t pedal){
     if (pedal >= NUMBER_OF_PEDALS) return 0;
-    int16_t millivoltsPedal = BSP_ADC_Get_Millivoltage(pedal);
+    int16_t millivoltsPedal = (int16_t) BSP_ADC_Get_Millivoltage(pedal);
 
     int8_t percentage = 0;
     
     if (millivoltsPedal >= LowerBound[pedal]) {
-        percentage = (millivoltsPedal - LowerBound[pedal]) * 100 /
-            (UpperBound[pedal] - LowerBound[pedal]);
+        percentage = (int8_t) (millivoltsPedal - LowerBound[pedal]) * 100 /
+         (UpperBound[pedal] - LowerBound[pedal]);
     }
 
     return percentage;


### PR DESCRIPTION
The pedals are wired in such a way that they don't actually use the full range of 0-3.3 volts. In order to account for this in the pedal driver, we now map a different voltage range (per pedal) to 0-100%. The values selected right now seem to work OK, but should definitely be tuned further by looking at the ADC out for the pedals and the corresponding percentage.