### PR TITLE
Pedals that go over 100% don't return garbage data now

### DIFF
--- a/Apps/Src/UpdateVelocity.c
+++ b/Apps/Src/UpdateVelocity.c
@@ -13,7 +13,7 @@ extern const float pedalToPercent[];
 // As of 03/13/2021 the function just returns a 1 to 1 conversion
 static float convertPedaltoMotorPercent(uint8_t pedalPercentage)
 {
-    return pedalToPercent[pedalPercentage];
+    return pedalPercentage > 100 ? 1.0f : pedalToPercent[pedalPercentage];
 }
 
 // Convert a float velocity to a desired RPM


### PR DESCRIPTION
Need to test this on the motor setup. This should eliminate the case where an unconnected brake pedal might allow the motor keep spinning.