### PR TITLE
RTOS Wrapper functions 

### DIFF
--- a/Apps/Inc/RTOS_Wrapper.h
+++ b/Apps/Inc/RTOS_Wrapper.h
@@ -1,0 +1,115 @@
+/* Copyright (c) 2018-2022 UT Longhorn Racing Solar */
+/*RTOS_ library includes all the wrapper functions for a functioning RTOS - needed for cleaner code and portability
+ */
+#ifndef RTOS_H
+#define RTOS_H
+
+#include "os.h" // for RTOS stuff
+#include <stdint.h>
+
+// Currently using Micrium
+typedef OS_MUTEX RTOS_MUTEX;
+typedef OS_SEM RTOS_SEM;
+typedef OS_OPT RTOS_OPT;
+typedef OS_ERR RTOS_ERR;
+typedef OS_SEM RTOS_SEM;
+typedef OS_TCB RTOS_TCB;
+typedef CPU_TS RTCPU_TS;
+typedef OS_SEM_CTR RTOS_SEM_CTR;
+typedef OS_TICK RTOS_TICK;
+
+// Custom typedefs for RTOS_TaskCreate function currently using micirium
+typedef OS_TCB RTOS_TCB;
+typedef CPU_STK RTOS_CPU_STK;
+
+/**
+ * @brief Pends a RTOS_Semaphore.
+ * @param *sem - pointer to a sempaphore to pend
+ * @param tick - time in clock ticks to timeout for
+ * @param opt - pend option
+ * @return the semaphore count, or 0 if not available
+ */
+RTOS_SEM_CTR RTOS_SemPend(RTOS_SEM *sem, RTOS_OPT opt);
+
+/**
+ * @brief Posts a semaphore
+ * @param sem4 this is a semaphore pointer to post to
+ * @param opt determines the type of POST performed
+ * @return The current value of the semaphore counter or 0 upon error
+ */
+RTOS_SEM_CTR RTOS_SemPost(RTOS_SEM *sem4, RTOS_OPT opt);
+
+/**
+ * @brief Initializes a mutex object.
+ * @param *mut - pointer to a mutex to initialize
+ * @param name - char* of the name of the mutex
+ * @return none
+ */
+void RTOS_MutexCreate(RTOS_MUTEX *mut, char *name);
+
+/**
+ * @brief   Function waits for Mutex
+ * @param   *mutex - pointer to mutex
+ * @param   options - determines what the mutex will do, ie: block or not block
+ */
+void RTOS_MutexPend(RTOS_MUTEX *mutex, RTOS_OPT opt);
+
+/**
+ * @brief   Posts the specified Mutex
+ * @param   *mutex - pointer to the specified RTOS Mutex object
+ * @param   options - a parameter which determines what kind of Post MutexPost performs
+ * @return  none
+ */
+void RTOS_MutexPost(RTOS_MUTEX *mutex, RTOS_OPT options);
+
+/**
+ * @brief   Creates a task that will be handled by the OS
+ * @param   *p_tcb - pointer to the tcb
+ * @param   *p_name - pointer to task name
+ * @param   p_task - pointer to the task
+ * @param   *p_args - pointer to task function arguments
+ * @param   *prio - task priority
+ * @param   *p_stk_base - the stack
+ * @param   stk_size - size of the stack
+ * @return  nothing to see here
+ */
+void RTOS_TaskCreate(
+    RTOS_TCB *p_tcb,
+    char *p_name,
+    void *p_task,
+    void *p_arg,
+    uint8_t prio,
+    RTOS_CPU_STK *p_stk_base,
+    uint64_t stk_size);
+
+/**
+ * @brief Creates a Second-based Time Delay.
+ * @param dly Defines how many seconds to delay for.
+ * @return none
+ */
+void RTOS_DelaySecs(uint16_t dly);
+
+/**
+ * @brief Creates a Millisecond-based Time Delay.
+ * @param dly Defines how many milliseconds to delay for.
+ * @return none
+ */
+void RTOS_DelayMs(uint16_t dly);
+
+/**
+ * @brief Creates a semaphore with the initially specified count
+ *
+ * @param sem - pointer to a semaphore object to create and initialize
+ * @param name - name of the semaphore
+ * @param count - initial count for the semaphore
+ */
+void RTOS_SemCreate(RTOS_SEM *sem, char *name, uint32_t count);
+
+/**
+ * @brief Creates a Tick-based Time Delay.
+ * @param dly Defines how many ticks to delay for.
+ * @return none
+ */
+void RTOS_DelayTick(RTOS_TICK dly);
+
+#endif

--- a/Apps/Inc/RTOS_Wrapper.h
+++ b/Apps/Inc/RTOS_Wrapper.h
@@ -28,18 +28,21 @@ typedef CPU_STK RTOS_CPU_STK;
 #endif
 
 #ifdef FREE_RTOS
-
+typedef TickType_t RTOS_TICK;
+typedef TimerCallbackFunction_t RTOS_TMR_CALLBACK_PTR;
+typedef TimerHandle_t RTOS_TMR;
+typedef SemaphoreHandle_t RTOS_MUTEX;
 #endif
 
-
-/**
- * @brief Pends a RTOS_Semaphore.
- * @param *sem - pointer to a sempaphore to pend
- * @param tick - time in clock ticks to timeout for
- * @param opt - pend option
- * @return the semaphore count, or 0 if not available
- */
-RTOS_SEM_CTR RTOS_SemPend(RTOS_SEM *sem, RTOS_OPT opt);
+    /**
+     * @brief Pends a RTOS_Semaphore.
+     * @param *sem - pointer to a sempaphore to pend
+     * @param tick - time in clock ticks to timeout for
+     * @param opt - pend option
+     * @return the semaphore count, or 0 if not available
+     */
+    RTOS_SEM_CTR
+    RTOS_SemPend(RTOS_SEM *sem, RTOS_OPT opt);
 
 /**
  * @brief Posts a semaphore
@@ -121,14 +124,20 @@ void RTOS_DelayTick(RTOS_TICK dly);
 
 /**
  * @brief: Creates a Tick-Based Time Delay.
+ * @param p_tmr is the pointer to the timer.
+ * @param p_name is name of the timer as a char string.
  * @param dly Defines how many ticks to delay for.
+ * @param period Defines how many ticks to set the period to.
+ * @param P_callback is the pointer to the function to be called when timer finishes.
+ * @param p_callback_arg i dont know.
+ * @param timerID i have no clue: FREE_RTOS describes it as "an identifier to the timer," but the FREE_RTOS create timer function already returns the timer handler(timer create intitalizes the timer rather than intitalizing and feeding it in as a paramater)
  * @return none
  */
-void RTOS_TimerCreate(RTOS_TMR p_tmr, char *p_name, RTOS_TICK dly, RTOS_TICK period, RTOS_TMR_CALLBACK_PTR P_callback, void *p_callback_arg);
+void RTOS_TimerCreate(RTOS_TMR p_tmr, char *p_name, RTOS_TICK dly, RTOS_TICK period, RTOS_TMR_CALLBACK_PTR P_callback, void *p_callback_arg, void *const timerID);
 
 /**
  * @brief: Creates a Tick-Based Time Delay.
- * @param dly Defines how many ticks to delay for.
+ * @param p_tmr specifies which timer handler to start.
  * @return none
  */
 void RTOS_TimerStart(RTOS_TMR p_tmr);

--- a/Apps/Inc/RTOS_Wrapper.h
+++ b/Apps/Inc/RTOS_Wrapper.h
@@ -21,7 +21,8 @@ typedef OS_TCB RTOS_TCB;
 typedef CPU_TS RTCPU_TS;
 typedef OS_SEM_CTR RTOS_SEM_CTR;
 typedef OS_TICK RTOS_TICK;
-
+typedef OS_TMR RTOS_TMR;
+typedef OS_TMR_CALLBACK_PTR RTOS_TMR_CALLBACK_PTR;
 typedef OS_TCB RTOS_TCB;
 typedef CPU_STK RTOS_CPU_STK;
 #endif
@@ -92,18 +93,15 @@ void RTOS_TaskCreate(
     uint64_t stk_size);
 
 /**
- * @brief Creates a Second-based Time Delay.
- * @param dly Defines how many seconds to delay for.
+ * @brief: Creates a Millisecond/second/minutes/hour-Based Time Delay.
+ * @param milli Defines how many milliseconds to delay for.
+ * @param seconds Defines how many seconds to delay for.
+ * @param minutes Defines how many minutes to delay for.
+ * @param hours Defines how many hours to delay for.
+ * @note if a (hours + minutes + seconds + milli) value is passed that is less time than the resolution of 1 tick, this code will error out
  * @return none
  */
-void RTOS_DelaySecs(uint16_t dly);
-
-/**
- * @brief Creates a Millisecond-based Time Delay.
- * @param dly Defines how many milliseconds to delay for.
- * @return none
- */
-void RTOS_DelayMs(uint16_t dly);
+void RTOS_DelayHMSM(CPU_INT16U hours, CPU_INT16U minutes, CPU_INT16U seconds, CPU_INT32U milli);
 
 /**
  * @brief Creates a semaphore with the initially specified count
@@ -120,5 +118,19 @@ void RTOS_SemCreate(RTOS_SEM *sem, char *name, uint32_t count);
  * @return none
  */
 void RTOS_DelayTick(RTOS_TICK dly);
+
+/**
+ * @brief: Creates a Tick-Based Time Delay.
+ * @param dly Defines how many ticks to delay for.
+ * @return none
+ */
+void RTOS_TimerCreate(RTOS_TMR p_tmr, char *p_name, RTOS_TICK dly, RTOS_TICK period, RTOS_TMR_CALLBACK_PTR P_callback, void *p_callback_arg);
+
+/**
+ * @brief: Creates a Tick-Based Time Delay.
+ * @param dly Defines how many ticks to delay for.
+ * @return none
+ */
+void RTOS_TimerStart(RTOS_TMR p_tmr);
 
 #endif

--- a/Apps/Inc/RTOS_Wrapper.h
+++ b/Apps/Inc/RTOS_Wrapper.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2022 UT Longhorn Racing Solar */
+/* Copyright (c) 2018-2023 UT Longhorn Racing Solar */
 /*RTOS_ library includes all the wrapper functions for a functioning RTOS - needed for cleaner code and portability
  */
 #ifndef RTOS_H
@@ -8,6 +8,10 @@
 #include <stdint.h>
 
 // Currently using Micrium
+#define MICRIUM
+// #define FREE_RTOS
+
+#ifdef MICRIUM
 typedef OS_MUTEX RTOS_MUTEX;
 typedef OS_SEM RTOS_SEM;
 typedef OS_OPT RTOS_OPT;
@@ -18,9 +22,14 @@ typedef CPU_TS RTCPU_TS;
 typedef OS_SEM_CTR RTOS_SEM_CTR;
 typedef OS_TICK RTOS_TICK;
 
-// Custom typedefs for RTOS_TaskCreate function currently using micirium
 typedef OS_TCB RTOS_TCB;
 typedef CPU_STK RTOS_CPU_STK;
+#endif
+
+#ifdef FREE_RTOS
+
+#endif
+
 
 /**
  * @brief Pends a RTOS_Semaphore.

--- a/Apps/Inc/Tasks.h
+++ b/Apps/Inc/Tasks.h
@@ -121,7 +121,8 @@ extern uint32_t StateOfCharge;
  * Stores error data to indicate which part of the code
  * an error is coming from.
  */
-typedef enum{
+typedef enum
+{
     OS_NONE_LOC = 0x000,
     OS_ARRAY_LOC = 0x001,
     OS_READ_CAN_LOC = 0x002,
@@ -134,7 +135,8 @@ typedef enum{
     OS_MAIN_LOC = 0x200,
     OS_CANDRIVER_LOC = 0x400,
     OS_MOTOR_CONNECTION_LOC = 0x800,
-    OS_DISPLAY_LOC = 0x1000
+    OS_DISPLAY_LOC = 0x1000,
+    OS_RTOS_WRAPPER_LOC = 0x2000
 } os_error_loc_t;
 
 /**

--- a/Apps/Src/RTOS_Wrapper.c
+++ b/Apps/Src/RTOS_Wrapper.c
@@ -107,27 +107,18 @@ void RTOS_MutexPost(RTOS_MUTEX *mutex, RTOS_OPT options)
 }
 
 /**
- * @brief: Creates a Second-Based Time Delay.
- * @param dly Defines how many seconds to delay for.
+ * @brief: Creates a Millisecond/second/minutes/hour-Based Time Delay.
+ * @param milli Defines how many milliseconds to delay for.
+ * @param seconds Defines how many seconds to delay for.
+ * @param minutes Defines how many minutes to delay for.
+ * @param hours Defines how many hours to delay for.
+ * @note if a (hours + minutes + seconds + milli) value is passed that is less time than the resolution of 1 tick, this code will error out
  * @return none
  */
-void RTOS_DelaySecs(uint16_t dly)
+void RTOS_DelayHMSM(CPU_INT16U hours, CPU_INT16U minutes, CPU_INT16U seconds, CPU_INT32U milli)
 {
     RTOS_ERR err;
-    OSTimeDlyHMSM(0, 0, (CPU_INT16U)dly, 0, OS_OPT_TIME_HMSM_NON_STRICT, &err);
-    assertOSError(OS_RTOS_WRAPPER_LOC, err);
-}
-
-/**
- * @brief: Creates a Millisecond-Based Time Delay.
- * @param dly Defines how many milliseconds to delay for.
- * @note if a dly value is passed that is less time than the resolution of 1 tick, this code will error out
- * @return none
- */
-void RTOS_DelayMs(uint16_t dly)
-{
-    RTOS_ERR err;
-    OSTimeDlyHMSM(0, 0, 0, (CPU_INT32U)dly, OS_OPT_TIME_HMSM_NON_STRICT, &err);
+    OSTimeDlyHMSM((CPU_INT16U)hours, (CPU_INT16U)minutes, (CPU_INT16U)seconds, (CPU_INT32U)milli, OS_OPT_TIME_HMSM_NON_STRICT, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
 }
 
@@ -141,4 +132,36 @@ void RTOS_DelayTick(RTOS_TICK dly)
     RTOS_ERR err;
     OSTimeDly(dly, OS_OPT_TIME_DLY, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
+}
+
+/**
+ * @brief: Creates a Tick-Based Time Delay.
+ * @param dly Defines how many ticks to delay for.
+ * @return none
+ */
+void RTOS_TimerCreate(RTOS_TMR p_tmr, char *p_name, RTOS_TICK dly, RTOS_TICK period, RTOS_TMR_CALLBACK_PTR P_callback, void *p_callback_arg)
+{
+    RTOS_ERR err;
+    OSTmrCreate(
+        &p_tmr,
+        p_name,
+        dly,
+        period,
+        OS_OPT_TMR_PERIODIC,
+        P_callback,
+        p_callback_arg,
+        &err);
+    assertOSError(OS_READ_CAN_LOC, err);
+}
+
+/**
+ * @brief: Creates a Tick-Based Time Delay.
+ * @param dly Defines how many ticks to delay for.
+ * @return none
+ */
+void RTOS_TimerStart(RTOS_TMR p_tmr)
+{
+    RTOS_ERR err;
+    OSTmrStart(&p_tmr, &err);
+    assertOSError(OS_READ_CAN_LOC, err);
 }

--- a/Apps/Src/RTOS_Wrapper.c
+++ b/Apps/Src/RTOS_Wrapper.c
@@ -1,0 +1,144 @@
+/* Copyright (c) 2018-2022 UT Longhorn Racing Solar */
+/*RTOS_ library includes all the wrapper functions for a functioning RTOS - needed for cleaner code and portability
+ */
+
+#include "RTOS_Wrapper.h"
+#include "Tasks.h" // for OS errors
+
+    /**
+     * @brief   Creates a task that will be handled by the OS
+     * @param   *p_tcb - pointer to the tcb
+     * @param   *p_name - pointer to task name
+     * @param   *p_task - pointer to the task
+     * @param   *p_args - pointer to task function arguments
+     * @param   prio - task priority
+     * @param   *p_stk_base - the stack
+     * @param   stk_size - size of the stack
+     * @param   *p_err - return error code
+     * @return  nothing to see here
+     */
+    void
+    RTOS_TaskCreate(RTOS_TCB *p_tcb, char *p_name, void *p_task, void *p_arg, uint8_t prio, RTOS_CPU_STK *p_stk_base, uint64_t stk_size)
+{
+    RTOS_ERR err;
+    OSTaskCreate(p_tcb, p_name, p_task, p_arg, prio, p_stk_base, stk_size, stk_size, 0, 10, (void *)0, OS_OPT_TASK_STK_CHK | OS_OPT_TASK_SAVE_FP, &err);
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+}
+
+/**
+ * @brief Creates a semaphore with the initially specified count
+ *
+ * @param sem - pointer to a semaphore object to create and initialize
+ * @param name - name of the semaphore
+ * @param count - initial count for the semaphore
+ */
+void RTOS_SemCreate(RTOS_SEM *sem, char *name, uint32_t count)
+{
+    RTOS_ERR err;
+    OSSemCreate(sem, name, count, &err);
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+}
+
+/**
+ * @brief Pends a RTOS_Semaphore.
+ * @param sem - pointer to a sempaphore to pend
+ * @param opt - pend option
+ * @return the semaphore count, or 0 if not available
+ */
+RTOS_SEM_CTR RTOS_SemPend(RTOS_SEM *sem, RTOS_OPT opt)
+{
+    RTOS_ERR err;
+    RTOS_SEM_CTR count = OSSemPend(sem, 0, opt, 0, &err); // we don't need timestamp
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+    return count;
+}
+
+/**
+ * @brief Posts a semaphore
+ * @param sem4 this is a semaphore pointer to post to
+ * @param opt determines the type of POST performed
+ * @return The current value of the semaphore counter or 0 upon error
+ */
+RTOS_SEM_CTR RTOS_SemPost(RTOS_SEM *sem4, RTOS_OPT opt)
+{
+    RTOS_ERR err;
+    RTOS_SEM_CTR counter = OSSemPost(sem4, opt, &err);
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+    return counter;
+}
+
+/**
+ * @brief Initializes a mutex object.
+ * @param *mut - pointer to a mutex to initialize
+ * @param name - char* of the name of the mutex
+ * @return none
+ */
+void RTOS_MutexCreate(RTOS_MUTEX *mut, char *name)
+{
+    RTOS_ERR err;
+    OSMutexCreate(mut, name, &err);
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+}
+
+/**
+ * @brief   Waits for Mutex, assigns timestamp and any error to err and ticks
+ * @param   *mutex - pointer to mutex
+ * @param   options - determines what the mutex will do, ie: block or not block
+ * @return  none
+ */
+void RTOS_MutexPend(RTOS_MUTEX *mutex, RTOS_OPT opt)
+{
+    RTOS_ERR err;
+    OSMutexPend(mutex, 0, opt, (void *)0, &err);
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+}
+
+/**
+ * @brief   Posts the specified Mutex. (For future reference, Post is the same as Give)
+ * @param   *mutex - pointer to the specified RTOS Mutex object
+ * @param   options - a parameter which determines what kind of Post MutexPost performs
+ * @return  none
+ */
+void RTOS_MutexPost(RTOS_MUTEX *mutex, RTOS_OPT options)
+{
+    RTOS_ERR err;
+    OSMutexPost(mutex, options, &err);
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+}
+
+/**
+ * @brief: Creates a Second-Based Time Delay.
+ * @param dly Defines how many seconds to delay for.
+ * @return none
+ */
+void RTOS_DelaySecs(uint16_t dly)
+{
+    RTOS_ERR err;
+    OSTimeDlyHMSM(0, 0, (CPU_INT16U)dly, 0, OS_OPT_TIME_HMSM_NON_STRICT, &err);
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+}
+
+/**
+ * @brief: Creates a Millisecond-Based Time Delay.
+ * @param dly Defines how many milliseconds to delay for.
+ * @note if a dly value is passed that is less time than the resolution of 1 tick, this code will error out
+ * @return none
+ */
+void RTOS_DelayMs(uint16_t dly)
+{
+    RTOS_ERR err;
+    OSTimeDlyHMSM(0, 0, 0, (CPU_INT32U)dly, OS_OPT_TIME_HMSM_NON_STRICT, &err);
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+}
+
+/**
+ * @brief: Creates a Tick-Based Time Delay.
+ * @param dly Defines how many ticks to delay for.
+ * @return none
+ */
+void RTOS_DelayTick(RTOS_TICK dly)
+{
+    RTOS_ERR err;
+    OSTimeDly(dly, OS_OPT_TIME_DLY, &err);
+    assertOSError(OS_RTOS_WRAPPER_LOC, err);
+}

--- a/Apps/Src/RTOS_Wrapper.c
+++ b/Apps/Src/RTOS_Wrapper.c
@@ -20,9 +20,15 @@
     void
     RTOS_TaskCreate(RTOS_TCB *p_tcb, char *p_name, void *p_task, void *p_arg, uint8_t prio, RTOS_CPU_STK *p_stk_base, uint64_t stk_size)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     OSTaskCreate(p_tcb, p_name, p_task, p_arg, prio, p_stk_base, stk_size, stk_size, 0, 10, (void *)0, OS_OPT_TASK_STK_CHK | OS_OPT_TASK_SAVE_FP, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
+    #endif
+
+    #ifdef FREE_RTOS
+
+    #endif
 }
 
 /**
@@ -34,9 +40,15 @@
  */
 void RTOS_SemCreate(RTOS_SEM *sem, char *name, uint32_t count)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     OSSemCreate(sem, name, count, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
+    #endif
+
+    #ifdef FREE_RTOS
+
+    #endif
 }
 
 /**
@@ -47,10 +59,16 @@ void RTOS_SemCreate(RTOS_SEM *sem, char *name, uint32_t count)
  */
 RTOS_SEM_CTR RTOS_SemPend(RTOS_SEM *sem, RTOS_OPT opt)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     RTOS_SEM_CTR count = OSSemPend(sem, 0, opt, 0, &err); // we don't need timestamp
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
     return count;
+    #endif
+
+    #ifdef FREE_RTOS
+
+    #endif
 }
 
 /**
@@ -61,10 +79,16 @@ RTOS_SEM_CTR RTOS_SemPend(RTOS_SEM *sem, RTOS_OPT opt)
  */
 RTOS_SEM_CTR RTOS_SemPost(RTOS_SEM *sem4, RTOS_OPT opt)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     RTOS_SEM_CTR counter = OSSemPost(sem4, opt, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
     return counter;
+    #endif
+
+    #ifdef FREE_RTOS
+
+    #endif
 }
 
 /**
@@ -75,35 +99,53 @@ RTOS_SEM_CTR RTOS_SemPost(RTOS_SEM *sem4, RTOS_OPT opt)
  */
 void RTOS_MutexCreate(RTOS_MUTEX *mut, char *name)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     OSMutexCreate(mut, name, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
+    #endif
+
+    #ifdef FREE_RTOS
+    mut* = xSemaphoreCreateMutex(void);
+    #endif
 }
 
 /**
  * @brief   Waits for Mutex, assigns timestamp and any error to err and ticks
  * @param   *mutex - pointer to mutex
- * @param   options - determines what the mutex will do, ie: block or not block
+ * @param   options - determines what the mutex will do, ie: block or not block (havent implemented for FREE_RTOS but it explains how to do it)
  * @return  none
  */
 void RTOS_MutexPend(RTOS_MUTEX *mutex, RTOS_OPT opt)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     OSMutexPend(mutex, 0, opt, (void *)0, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
+    #endif
+
+    #ifdef FREE_RTOS
+    xSemaphoreTake( mutex*, 0); //wrong and unfinished
+#endif
 }
 
 /**
  * @brief   Posts the specified Mutex. (For future reference, Post is the same as Give)
  * @param   *mutex - pointer to the specified RTOS Mutex object
- * @param   options - a parameter which determines what kind of Post MutexPost performs
+ * @param   options - a parameter which determines what kind of Post MutexPost performs (havent implemented for FREE_RTOS but it explains how to do it)
  * @return  none
  */
 void RTOS_MutexPost(RTOS_MUTEX *mutex, RTOS_OPT options)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     OSMutexPost(mutex, options, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
+    #endif
+
+    #ifdef FREE_RTOS
+    xSemaphoreGive(mutex *); // wrong and unfinished
+#endif
 }
 
 /**
@@ -117,9 +159,15 @@ void RTOS_MutexPost(RTOS_MUTEX *mutex, RTOS_OPT options)
  */
 void RTOS_DelayHMSM(CPU_INT16U hours, CPU_INT16U minutes, CPU_INT16U seconds, CPU_INT32U milli)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     OSTimeDlyHMSM((CPU_INT16U)hours, (CPU_INT16U)minutes, (CPU_INT16U)seconds, (CPU_INT32U)milli, OS_OPT_TIME_HMSM_NON_STRICT, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
+    #endif
+
+    #ifdef FREE_RTOS
+
+    #endif
 }
 
 /**
@@ -129,18 +177,31 @@ void RTOS_DelayHMSM(CPU_INT16U hours, CPU_INT16U minutes, CPU_INT16U seconds, CP
  */
 void RTOS_DelayTick(RTOS_TICK dly)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     OSTimeDly(dly, OS_OPT_TIME_DLY, &err);
     assertOSError(OS_RTOS_WRAPPER_LOC, err);
+    #endif
+
+    #ifdef FREE_RTOS
+
+    #endif
 }
 
 /**
  * @brief: Creates a Tick-Based Time Delay.
+ * @param p_tmr is the pointer to the timer.
+ * @param p_name is name of the timer as a char string.
  * @param dly Defines how many ticks to delay for.
+ * @param period Defines how many ticks to set the period to.
+ * @param P_callback is the pointer to the function to be called when timer finishes.
+ * @param p_callback_arg i dont know.
+ * @param timerID i have no clue: FREE_RTOS describes it as "an identifier to the timer," but the FREE_RTOS create timer function already returns the timer handler(timer create intitalizes the timer rather than intitalizing and feeding it in as a paramater)
  * @return none
  */
-void RTOS_TimerCreate(RTOS_TMR p_tmr, char *p_name, RTOS_TICK dly, RTOS_TICK period, RTOS_TMR_CALLBACK_PTR P_callback, void *p_callback_arg)
+void RTOS_TimerCreate(RTOS_TMR p_tmr, char *p_name, RTOS_TICK dly, RTOS_TICK period, RTOS_TMR_CALLBACK_PTR P_callback, void *p_callback_arg, void *const timerID)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     OSTmrCreate(
         &p_tmr,
@@ -152,16 +213,37 @@ void RTOS_TimerCreate(RTOS_TMR p_tmr, char *p_name, RTOS_TICK dly, RTOS_TICK per
         p_callback_arg,
         &err);
     assertOSError(OS_READ_CAN_LOC, err);
+    #endif
+    
+#ifdef FREE_RTOS
+    RTOS_ERR err;
+    p_tmr = xTimerCreate(
+        (char *)p_name,
+        (RTOS_TICK)period,
+        (UBaseType_t)pdFALSE,
+        (void *const)timerID,
+        (RTOS_TMR_CALLBACK_PTR)P_callback);
+    assertOSError(OS_READ_CAN_LOC, err);
+#endif
 }
 
 /**
  * @brief: Creates a Tick-Based Time Delay.
- * @param dly Defines how many ticks to delay for.
+ * @param p_tmr specifies which timer handler to start.
  * @return none
  */
 void RTOS_TimerStart(RTOS_TMR p_tmr)
 {
+    #ifdef MICRIUM
     RTOS_ERR err;
     OSTmrStart(&p_tmr, &err);
     assertOSError(OS_READ_CAN_LOC, err);
+    #endif
+
+    #ifdef FREE_RTOS
+    BaseType_t WasQueueSuccessful;
+    WasQueueSuccessful = xTimerStart(
+        (RTOS_TMR)p_tmr,
+        (RTOS_TICK)0); // blocking function: blocks start for __ ticks
+    #endif
 }


### PR DESCRIPTION
This is the BPS Wrapper c and h files from their task directory, copied into the Controls Apps directory. Instead of BPS' new RTOS_BPS_ labeling, I changed it to RTOS_, and lastly, I added OS_RTOS_WRAPPER_LOC error into the Tasks.h os_error_loc_t enum to be used in the assertOSError() functions.


This is my second pull request and the correct one!