### PR TITLE
Fix floating point context switch issue

### DIFF
--- a/Apps/Src/main.c
+++ b/Apps/Src/main.c
@@ -43,7 +43,7 @@ int main(void) {
         (OS_MSG_QTY)0,
         (OS_TICK)0,
         (void*)NULL,
-        (OS_OPT)(OS_OPT_TASK_STK_CLR),
+        (OS_OPT)(OS_OPT_TASK_STK_CLR|OS_OPT_TASK_SAVE_FP),
         (OS_ERR*)&err
     );
     assertOSError(err);
@@ -98,7 +98,7 @@ void Task_Init(void *p_arg){
         (OS_MSG_QTY)0,
         (OS_TICK)0,
         (void*)NULL,
-        (OS_OPT)(OS_OPT_TASK_STK_CLR),
+        (OS_OPT)(OS_OPT_TASK_STK_CLR|OS_OPT_TASK_SAVE_FP|OS_OPT_TASK_SAVE_FP),
         (OS_ERR*)&err
     );
     assertOSError(err);
@@ -116,7 +116,7 @@ void Task_Init(void *p_arg){
         (OS_MSG_QTY)0,
         (OS_TICK)0,
         (void*)NULL,
-        (OS_OPT)(OS_OPT_TASK_STK_CLR),
+        (OS_OPT)(OS_OPT_TASK_STK_CLR|OS_OPT_TASK_SAVE_FP|OS_OPT_TASK_SAVE_FP),
         (OS_ERR*)&err
     );
     assertOSError(err);
@@ -134,7 +134,7 @@ void Task_Init(void *p_arg){
         (OS_MSG_QTY)0,
         (OS_TICK)0,
         (void*)NULL,
-        (OS_OPT)(OS_OPT_TASK_STK_CLR),
+        (OS_OPT)(OS_OPT_TASK_STK_CLR|OS_OPT_TASK_SAVE_FP|OS_OPT_TASK_SAVE_FP),
         (OS_ERR*)&err
     );
     assertOSError(err);
@@ -152,7 +152,7 @@ void Task_Init(void *p_arg){
         (OS_MSG_QTY)0,
         (OS_TICK)0,
         (void*)NULL,
-        (OS_OPT)(OS_OPT_TASK_STK_CLR),
+        (OS_OPT)(OS_OPT_TASK_STK_CLR|OS_OPT_TASK_SAVE_FP|OS_OPT_TASK_SAVE_FP),
         (OS_ERR*)&err
     );
     assertOSError(err);
@@ -170,7 +170,7 @@ void Task_Init(void *p_arg){
         (OS_MSG_QTY)0,
         (OS_TICK)0,
         (void*)NULL,
-        (OS_OPT)(OS_OPT_TASK_STK_CLR),
+        (OS_OPT)(OS_OPT_TASK_STK_CLR|OS_OPT_TASK_SAVE_FP|OS_OPT_TASK_SAVE_FP),
         (OS_ERR*)&err
     );
     assertOSError(err);

--- a/BSP/STM32F413/Src/startup_stm32f413xx.s
+++ b/BSP/STM32F413/Src/startup_stm32f413xx.s
@@ -105,6 +105,11 @@ LoopFillZerobss:
   cmp  r2, r3
   bcc  FillZerobss
 
+  ldr r3, =0xE000EF34 @ FPCCR
+  ldr r2, [r3]
+  bic r2, 0xc0000000 @ Clear LSPEN and ASPEN
+  str r2, [r3]
+
 /* Call the clock system intitialization function.*/
   bl  SystemInit   
 /* Call static constructors */

--- a/Tests/Test_Float.c
+++ b/Tests/Test_Float.c
@@ -1,7 +1,7 @@
 /**
  * Test file for testing floating point register restoration on context switch
  * 
- * To be tested on hardware
+ * To be tested on hardware, if it doesn't hard fault then it worked!
  */
 
 

--- a/Tests/Test_Float.c
+++ b/Tests/Test_Float.c
@@ -1,0 +1,76 @@
+/**
+ * Test file for testing floating point register restoration on context switch
+ * 
+ * To be tested on hardware
+ */
+
+
+#include "common.h"
+#include "config.h"
+#include "stm32f4xx.h"
+#include <bsp.h>
+
+static OS_TCB Task1_TCB;
+static CPU_STK Task1_Stk[128];
+static OS_TCB Task2_TCB;
+static CPU_STK Task2_Stk[128];
+
+void Task2(void *p_arg) {
+    OS_ERR err;
+
+    volatile float x = 7.8f;
+    x *= 1.5f;
+    x -= 8.7f;
+    OSTimeDlyHMSM(0, 0, 2, 0, OS_OPT_TIME_HMSM_STRICT, &err);
+    x /= 3.0f;
+    OSTimeDlyHMSM(1, 0, 0, 0, OS_OPT_TIME_HMSM_STRICT, &err);
+}
+
+void Task1(void *p_arg) {
+    CPU_Init();
+    // OS_CPU_SysTickInit();
+    OS_CPU_SysTickInit(SystemCoreClock / (CPU_INT32U) OSCfg_TickRate_Hz);
+    OS_ERR err;
+
+    OSTaskCreate(&Task2_TCB, "Task2", Task2, NULL, 5, Task2_Stk, 64, 128, 0, 0, NULL, OS_OPT_TASK_SAVE_FP|OS_OPT_TASK_STK_CHK, &err);
+    volatile float x = 3.7f;
+    x *= 2.0f;
+    x += 8.7f;
+    OSTimeDlyHMSM(0, 0, 2, 0, OS_OPT_TIME_HMSM_STRICT, &err);
+    x /= 1.5f;
+    OSTimeDlyHMSM(1, 0, 0, 0, OS_OPT_TIME_HMSM_STRICT, &err);
+   
+}
+
+int main(void) {
+    OS_ERR err;
+    OSInit(&err);
+    if(err != OS_ERR_NONE){
+        printf("OS error code %d\n",err);
+    }
+    OSTaskCreate(
+        (OS_TCB*)&Task1_TCB,
+        (CPU_CHAR*)"Task1",
+        (OS_TASK_PTR)Task1,
+        (void*)NULL,
+        (OS_PRIO)4,
+        (CPU_STK*)Task1_Stk,
+        (CPU_STK_SIZE)sizeof(Task1_Stk)/10,
+        (CPU_STK_SIZE)sizeof(Task1_Stk),
+        (OS_MSG_QTY)0,
+        (OS_TICK)NULL,
+        (void*)NULL,
+        (OS_OPT)(OS_OPT_TASK_SAVE_FP|OS_OPT_TASK_STK_CHK),
+        (OS_ERR*)&err
+    );
+
+    if (err != OS_ERR_NONE) {
+        printf("Task1 error code %d\n", err);
+    }
+    OSStart(&err);
+    if (err != OS_ERR_NONE) {
+        printf("OS error code %d\n", err);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Clear the ASPEN and LSPEN bits in the FPCCR. Combined with OS_OPT_TASK_SAVE_FP, the RTOS no longer hard fautls when trying to restore FP context.

# Quality Assurance Checklist 
To make reviews more efficient, please make sure the software feature meets the following standards and check everything off that meets the quality check. Once everything has been checked, the assigned reviewers will begin the review process. _Edit this description to check off the list._

There are exceptions with all guidelines. As long as your decisions are justified, then you are good! Contact the reviewers or the leads about any exceptions. 

## Requirements 
- [x] Followed Coding Style Guide 
- [x] Presented/discussed in some capacity with others on the Controls team
- [x] Code Build checks pass 
- [x] No merge conflicts 
- [ ] Software feature has documentation for it updated in both ReadTheDocs and the comments
- [ ] Software feature has documentation for it updated
- Testing
    - [x] Software feature has test associated with it
    - [x] Test provides useful information and uses relevant data to accurately represent Controls 
    - [x] Tested on hardware
    - NOTE: If test file already exists, use that one
- [x] If applicable, have you added the new feature to main.c?
- [x] Tagged appropriate issue ticket on this PR
- [x] Did you have fun?

## Things to Consider 
- [x] Even if the above are checked, is this the best way of writing my code? 
    - It's possible to write code that works, but are there ways to make code more efficient? 
