### PR TITLE
Modifed Minions to flip ignition switch pins input

### DIFF
--- a/Apps/Src/DebugDump.c
+++ b/Apps/Src/DebugDump.c
@@ -35,8 +35,7 @@ void TaskDebugDump(void *p_arg) {
         for (Pin pin = 0; pin < kNumPins; pin++) {
             bool pin_state = MinionsRead(pin);
             // Ignition pins are negative logic, special-case them
-            printf("%s: %s\n\r", minionpin_string[pin],
-                   pin_state ^ (pin == kIgn1 || pin == kIgn2) ? "on" : "off");
+            printf("%s: %s\n\r", minionpin_string[pin], pin_state ? "on" : "off");
         }
 
         // Get contactor info

--- a/Apps/Src/DebugDump.c
+++ b/Apps/Src/DebugDump.c
@@ -35,7 +35,8 @@ void TaskDebugDump(void *p_arg) {
         for (Pin pin = 0; pin < kNumPins; pin++) {
             bool pin_state = MinionsRead(pin);
             // Ignition pins are negative logic, special-case them
-            printf("%s: %s\n\r", minionpin_string[pin], pin_state ? "on" : "off");
+            printf("%s: %s\n\r", minionpin_string[pin],
+                   pin_state ? "on" : "off");
         }
 
         // Get contactor info

--- a/Apps/Src/ReadCarCan.c
+++ b/Apps/Src/ReadCarCan.c
@@ -295,8 +295,8 @@ void TurnMotorControllerPbcOff(void) {
  * @param None
  */
 void UpdatePrechargeContactors(void) {
-    arr_ign_status = (!MinionsRead(kIgn1));
-    mc_ign_status = (!MinionsRead(kIgn2));
+    arr_ign_status = (MinionsRead(kIgn1));
+    mc_ign_status = (MinionsRead(kIgn2));
 
     // Logic helper in cases both are off or (impossible) on
     bool both_status_off = !mc_ign_status && !arr_ign_status;

--- a/Apps/Src/SendCarCan.c
+++ b/Apps/Src/SendCarCan.c
@@ -158,7 +158,7 @@ static void putIOState(void) {
     }
 
     // Tell BPS if the array contactor should be on
-    message.data[3] |= (!MinionsRead(kIgn1) || !MinionsRead(kIgn2)) << 2;
+    message.data[3] |= (MinionsRead(kIgn1) || MinionsRead(kIgn2)) << 2;
 
     CanBusSend(message, true, CARCAN);
 }

--- a/Drivers/Src/Minions.c
+++ b/Drivers/Src/Minions.c
@@ -24,13 +24,14 @@ bool MinionsRead(Pin pin) {
     if ((kPininfoLut[pin].direction == kInput)) {
         if (pin == kIgn1 || pin == kIgn2) {
             return !((bool)BspGpioReadPin(kPininfoLut[pin].port,
-                                        kPininfoLut[pin].pin_mask));
+                                          kPininfoLut[pin].pin_mask));
         }
-        else {
-            return (bool)BspGpioReadPin(kPininfoLut[pin].port,
-                                        kPininfoLut[pin].pin_mask);
-        }
+        return (bool)BspGpioReadPin(kPininfoLut[pin].port,
+                                    kPininfoLut[pin].pin_mask);
     }
+
+    return (bool)BspGpioGetState(kPininfoLut[pin].port,
+                                 kPininfoLut[pin].pin_mask);
 }
 
 bool MinionsWrite(Pin pin, bool status) {

--- a/Drivers/Src/Minions.c
+++ b/Drivers/Src/Minions.c
@@ -22,11 +22,15 @@ void MinionsInit(void) {
 
 bool MinionsRead(Pin pin) {
     if ((kPininfoLut[pin].direction == kInput)) {
-        return (bool)BspGpioReadPin(kPininfoLut[pin].port,
-                                    kPininfoLut[pin].pin_mask);
+        if (pin == kIgn1 || pin == kIgn2) {
+            return !((bool)BspGpioReadPin(kPininfoLut[pin].port,
+                                        kPininfoLut[pin].pin_mask));
+        }
+        else {
+            return (bool)BspGpioReadPin(kPininfoLut[pin].port,
+                                        kPininfoLut[pin].pin_mask);
+        }
     }
-    return (bool)BspGpioGetState(kPininfoLut[pin].port,
-                                 kPininfoLut[pin].pin_mask);
 }
 
 bool MinionsWrite(Pin pin, bool status) {


### PR DESCRIPTION
# Quality Assurance Checklist 
Modified minions read pin function to flip the input of ignition switch so that we don't have to flip manually during application code.

## Requirements 
- [x] Followed Coding Style Guide 
- [x] Presented/discussed in some capacity with others on the Controls team
- [x] Code Build checks pass 
- [x] No merge conflicts 
- [x] Software feature has documentation for it updated in both ReadTheDocs and the comments
- [x] Software feature has documentation for it updated
- Testing
    - [ ] Software feature has test associated with it
    - [ ] Test provides useful information and uses relevant data to accurately represent Controls 
    - [ ] Tested on hardware
    - NOTE: If test file already exists, use that one
- [x] If applicable, have you added the new feature to main.c?
- [x] Tagged appropriate issue ticket on this PR
- [x] Did you have fun?

## Things to Consider 
- [x] Even if the above are checked, is this the best way of writing my code? 
    - It's possible to write code that works, but are there ways to make code more efficient? 
